### PR TITLE
Deploy for result data service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ data "terraform_remote_state" "state" {
 
 module "cosmotech-tenant" {
   source  = "Cosmo-Tech/cosmotech-tenant/azure"
-  version = "1.1.12"
+  version = "1.1.13"
 
   # Azure tenant prerequisites
   tenant_id                              = var.tenant_id

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ module "cosmotech-tenant" {
   create_backup                                = var.create_backup
   create_cosmosdb                              = var.create_cosmosdb
   create_adx                                   = var.create_adx
+  create_eventhub                              = var.create_eventhub
   common_platform_object_id                    = var.common_platform_object_id
 
   blob_privatedns_zonename     = var.blob_privatedns_zonename
@@ -112,4 +113,5 @@ module "cosmotech-tenant" {
   network_client_secret              = var.network_client_secret
   tenant_client_id                   = var.tenant_client_id
   tenant_client_secret               = var.tenant_client_secret
+  create_rabbitmq                    = var.create_rabbitmq
 }

--- a/variables.tf
+++ b/variables.tf
@@ -404,6 +404,18 @@ variable "create_adx" {
   default     = true
 }
 
+variable "create_eventhub" {
+  description = "Whether to create Azure Event Hub resources"
+  type        = bool
+  default     = true
+}
+
+variable "create_rabbitmq" {
+  description = "Whether to create RabbitMQ resources"
+  type        = bool
+  default     = false
+}
+
 variable "create_babylon" {
   description = "Create the Azure Active Directory Application for Babylon"
   type        = bool


### PR DESCRIPTION
Deployment modifications for the result data service:
* Add new variables entries `create_eventhub` and `create_rabbit` to match the equivalent entries in the generic repo
* Bump generic tenant repo/module version to match the future tag (to update if another tag happens before merging the PR)