### PR TITLE
API configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,4 +114,5 @@ module "cosmotech-tenant" {
   tenant_client_id                   = var.tenant_client_id
   tenant_client_secret               = var.tenant_client_secret
   create_rabbitmq                    = var.create_rabbitmq
+  list_apikey_allowed                = var.list_apikey_allowed
 }

--- a/variables.tf
+++ b/variables.tf
@@ -724,3 +724,18 @@ variable "backend_remote" {
 variable "common_platform_object_id" {
   type = string
 }
+
+variable "list_apikey_allowed" {
+  type = list(object({
+    name = string
+    apiKey = string
+    associatedRole = string
+    securedUris = list(string)
+  }))
+  default = [ {
+      name = ""
+      apiKey = ""
+      associatedRole = ""
+      securedUris = []
+  } ]
+}


### PR DESCRIPTION
Add the allowedApiKeyConsumers to the API configuration:
In terraform.tfvars, we need to pass this variable in this structure:
```
list_apikey_allowed = [
  {
    name           = "some name"
    apiKey         = "some api key"
    associatedRole = "Platform role"
    securedUris    = [
      "/organizations",
      "/organizations/.*/workspaces",
      "/organizations/.*/workspaces/.*/runners",
      "/organizations/.*/workspaces/.*/runners/.*/runs"                                            
    ]
  },
  {
    name           = "some name"
    apiKey         = "some api key"
    associatedRole = ""
    securedUris    = []
  }
]
```
